### PR TITLE
Feature/remove attr

### DIFF
--- a/pablo.js
+++ b/pablo.js
@@ -441,7 +441,7 @@ var Pablo = (function(document, Array, JSON, Element, NodeList){
         
         removeAttr: function (attr) {
             this.each(function (el, i){
-                console.log('stop');
+                el.removeAttribute(attr);
             })
         },
 


### PR DESCRIPTION
This was _deceptively_ simple to write.

Usage:
`Pablo('circle').remoteAttr('fill')`

However it does not get rid of related styles.

For example some circles will still have a inline css style applied of fill. I'm not sure in Pablo's relation to applying styles.
