### PR TITLE
Added bower.json file to support installation from bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,22 @@
+{
+  "name": "pablo",
+  "main": "pablo.js",
+  "version": "0.3.2",
+  "homepage": "http://pablojs.com",
+  "authors": [
+    "Premasagar Rose <http://premasagar.com>"
+  ],
+  "description": "A tool for creating interactive SVG drawings and animations for the web",
+  "keywords": [
+    "svg"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests",
+    "Gruntfile.js"
+  ]
+}


### PR DESCRIPTION
Hey! Here's the `bower.json` file, just like I promised :)

Pablo now shows up in the bower packages. But in order for bower to show the contents of the `bower.json` file, you need to have git tags for each Pablo version/release (using semver). This is not required, but it improves the metadata and allows users to define specific version dependencies in their projects.

You can now install Pablo with `bower install pablo` :)
