### PR TITLE
Fix IE11 detection

### DIFF
--- a/pablo.js
+++ b/pablo.js
@@ -33,7 +33,7 @@
             match = /((webkit))[ \/]([\w.]+)/.exec(ua) ||
                     /((o)pera)(?:.*version|)[ \/]([\w.]+)/.exec(ua) ||
                     /((trident))(?:.*? rv:([\w.]+)|)/.exec(ua) ||
-                    /((ms)ie) ([\w.]+)/i.exec(ua) ||
+                    /((ms)ie) ([\w.]+)/.exec(ua) ||
                     ua.indexOf("compatible") < 0 &&
                         /((moz)illa)(?:.*? rv:([\w.]+)|)/.exec(ua),
             name, prefix, version;


### PR DESCRIPTION
Browser detection is broken for IE11: `ua` string is lowercased, but `"Trident"` string begins with a capital letter. As a result, prefix is not determined correctly (`name == "mozilla"`, `prefix == "moz"`) and `Pablo.isSupported` is set to `false`.
